### PR TITLE
Add support for exporting games as PGN

### DIFF
--- a/crates/lictl/src/cmd/games/export.rs
+++ b/crates/lictl/src/cmd/games/export.rs
@@ -1,0 +1,16 @@
+use crate::{constants::API_BASE, context::Context};
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+pub async fn run(ctx: &Context, game_id: &str) -> Result<Value> {
+    let url = format!("{}/game/export/{}", API_BASE, game_id);
+
+    let response = ctx.client.get(&url).send().await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!("Failed to export game: {}", response.status()));
+    }
+
+    let pgn = response.text().await?;
+    Ok(Value::String(pgn))
+}

--- a/crates/lictl/src/cmd/games/mod.rs
+++ b/crates/lictl/src/cmd/games/mod.rs
@@ -1,0 +1,20 @@
+use crate::context::Context;
+use anyhow::Result;
+use clap::Subcommand;
+use serde_json::Value;
+mod export;
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Export a game as PGN
+    Export {
+        /// The ID of the game
+        game_id: String,
+    },
+}
+
+pub async fn run(ctx: &Context, cmd: Commands) -> Result<Value> {
+    match cmd {
+        Commands::Export { game_id } => export::run(ctx, &game_id).await,
+    }
+}

--- a/crates/lictl/src/cmd/mod.rs
+++ b/crates/lictl/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod broadcast_rounds;
 pub mod broadcasts;
+pub mod games;
 pub mod login;
 pub mod logout;
 pub mod req;

--- a/crates/lictl/src/main.rs
+++ b/crates/lictl/src/main.rs
@@ -23,6 +23,8 @@ enum Commands {
     #[command(subcommand)]
     Broadcasts(cmd::broadcasts::Commands),
     #[command(subcommand)]
+    Games(cmd::games::Commands),
+    #[command(subcommand)]
     Studies(cmd::studies::Commands),
     #[command(subcommand)]
     BroadcastRounds(cmd::broadcast_rounds::Commands),
@@ -40,6 +42,7 @@ async fn main() -> Result<()> {
         Commands::Logout => cmd::logout::run().await?,
         Commands::Whoami => cmd::whoami::run(&context).await?,
         Commands::Broadcasts(cmd) => cmd::broadcasts::run(&context, cmd).await?,
+        Commands::Games(cmd) => cmd::games::run(&context, cmd).await?,
         Commands::Studies(cmd) => cmd::studies::run(&context, cmd).await?,
         Commands::BroadcastRounds(cmd) => cmd::broadcast_rounds::run(&context, cmd).await?,
         Commands::Req(cmd) => cmd::req::run(&context, cmd).await?,


### PR DESCRIPTION
Fixes #1

This PR adds support for exporting games from Lichess as PGN format. It implements a new `games` command with an `export` subcommand that takes a game ID as an argument.

Example usage:
```
lictl games export <GAME_ID>
```