### PR TITLE
Add OpenHands setup.sh file that installs Rust

### DIFF
--- a/.openhands/microagents/repo.md
+++ b/.openhands/microagents/repo.md
@@ -1,0 +1,43 @@
+# Repository Guidelines for OpenHands
+
+## Build Process
+
+When working with this Rust project:
+
+- Always run `cargo check` before `cargo build` to save time checking for errors
+- Always run `cargo fmt --check` to check for formatting errors before opening a PR
+
+## Commit Messages
+
+This repository follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages.
+
+### Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation only changes
+- `style`: Changes that do not affect the meaning of the code (white-space, formatting, etc)
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `perf`: A code change that improves performance
+- `test`: Adding missing tests or correcting existing tests
+- `build`: Changes that affect the build system or external dependencies
+- `ci`: Changes to our CI configuration files and scripts
+- `chore`: Other changes that don't modify src or test files
+
+### Examples
+
+```
+feat: add new CLI command for listing resources
+fix(parser): handle edge case in JSON parsing
+docs: update installation instructions
+```

--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Check if Rust is already installed
+if command -v rustc &> /dev/null && command -v cargo &> /dev/null; then
+    echo "Rust is already installed. Updating..."
+    rustup update
+else
+    echo "Installing Rust..."
+    # Install Rust using rustup
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    
+    # Add Rust to the PATH for the current session
+    source "$HOME/.cargo/env"
+fi
+
+# Verify installation
+echo "Rust installation complete:"
+rustc --version
+cargo --version
+
+echo "Rust setup completed successfully!"


### PR DESCRIPTION
Fixes #4

This PR adds:
- `.openhands/setup.sh` file that installs the Rust toolchain
- `.openhands/microagents/repo.md` with guidelines for:
  - Running `cargo check` before `cargo build`
  - Running `cargo fmt --check` before opening a PR
  - Using conventional commit messages

This will simplify OpenHands tasks by ensuring the Rust toolchain is properly installed.