### PR TITLE
Add pre-commit hooks for cargo fmt and clippy

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -19,4 +19,22 @@ echo "Rust installation complete:"
 rustc --version
 cargo --version
 
-echo "Rust setup completed successfully!"
+# Install pre-commit
+if command -v pre-commit &> /dev/null; then
+    echo "pre-commit is already installed. Updating..."
+    pip install --upgrade pre-commit
+else
+    echo "Installing pre-commit..."
+    pip install pre-commit
+fi
+
+# Verify pre-commit installation
+echo "pre-commit installation complete:"
+pre-commit --version
+
+# Install pre-commit hooks
+echo "Installing pre-commit hooks..."
+cd "$(git rev-parse --show-toplevel)" # Navigate to the root of the git repository
+pre-commit install
+
+echo "Setup completed successfully!"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        description: Format Rust code using rustfmt
+        entry: cargo fmt --all
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        description: Run clippy on Rust code
+        entry: cargo clippy -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -81,10 +81,36 @@ cargo build
 cargo build --release
 ```
 
+### Pre-commit Hooks
+
+This project uses pre-commit hooks to ensure code quality. The hooks run `cargo fmt` and `cargo clippy` before each commit.
+
+To set up the pre-commit hooks:
+
+```bash
+# Run the setup script
+./.openhands/setup.sh
+
+# Or manually install pre-commit and the hooks
+pip install pre-commit
+pre-commit install
+```
+
+The hooks will automatically run when you commit changes. You can also run them manually:
+
+```bash
+# Run all hooks on all files
+pre-commit run --all-files
+
+# Run a specific hook
+pre-commit run cargo-fmt
+pre-commit run cargo-clippy
+```
+
 ## Contributing
 
 1. Fork the repository
 2. Create a feature branch
-3. Commit your changes
+3. Commit your changes (pre-commit hooks will ensure code quality)
 4. Push to the branch
 5. Create a Pull Request


### PR DESCRIPTION
This PR adds pre-commit hooks to run `cargo fmt` and `cargo clippy` before committing. The hooks are configured using pre-commit (https://pre-commit.com/).

Changes include:
- Added `.pre-commit-config.yaml` with hooks for cargo fmt and clippy
- Updated `.openhands/setup.sh` to install pre-commit and set up the hooks
- Updated README.md with instructions on how to use the pre-commit hooks

This PR fixes #11

@ddaws can click here to [continue refining the PR](https://app.all-hands.dev/conversations/27ed3d160366420494bfa7bf34d181bd)