### PR TITLE
Add subcommand to export chapter PGN from a study

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ lictl broadcast-rounds get <round-id>
 ### Studies
 
 ```bash
+# Export chapter PGN for a study
+lictl studies export <study-id> <chapter-id>
+```
+
+```bash
 # Import PGN into a study
 lictl studies import <study-id> "<pgn-content>"
 ```

--- a/crates/lictl/src/cmd/studies/export.rs
+++ b/crates/lictl/src/cmd/studies/export.rs
@@ -1,0 +1,16 @@
+use crate::{constants::API_BASE, context::Context};
+use anyhow::{Result, anyhow};
+use serde_json::Value;
+
+pub async fn run(ctx: &Context, study_id: &str, chapter_id: &str) -> Result<Value> {
+    let url = format!("{}/study/{}/{}.pgn", API_BASE, study_id, chapter_id);
+
+    let response = ctx.client.get(&url).send().await?;
+
+    if !response.status().is_success() {
+        return Err(anyhow!("Failed to export study: {}", response.status()));
+    }
+
+    let pgn = response.text().await?;
+    Ok(Value::String(pgn))
+}

--- a/crates/lictl/src/cmd/studies/mod.rs
+++ b/crates/lictl/src/cmd/studies/mod.rs
@@ -3,10 +3,18 @@ use anyhow::Result;
 use clap::Subcommand;
 use serde_json::Value;
 
+mod export;
 mod import;
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Export a chapter from a study
+    Export {
+        /// The ID of the study
+        study_id: String,
+        /// THe ID of the chapter
+        chapter_id: String,
+    },
     /// Import a PGN into a study
     Import {
         /// The ID of the study
@@ -18,6 +26,10 @@ pub enum Commands {
 
 pub async fn run(ctx: &Context, cmd: Commands) -> Result<Value> {
     match cmd {
+        Commands::Export {
+            study_id,
+            chapter_id,
+        } => export::run(ctx, &study_id, &chapter_id).await,
         Commands::Import { study_id, args } => import::run(ctx, &study_id, args).await,
     }
 }


### PR DESCRIPTION
This patch adds the `studies export` subcommand that exports the chapter PGN from a study.

----

Thanks for this nice tool! I need some more features for my personal use so I’ll try to make some contributions for these features.